### PR TITLE
Enable auto-publication to /TR

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -12,3 +12,7 @@ jobs:
       - uses: w3c/spec-prod@v2
         with:
           GH_PAGES_BRANCH: gh-pages
+          W3C_ECHIDNA_TOKEN: ${{ secrets.ECHIDNA_TOKEN }}
+          W3C_WG_DECISION_URL: https://lists.w3.org/Archives/Public/public-secondscreen/2022Apr/0007.html
+          W3C_BUILD_OVERRIDE: |
+            Status: WD


### PR DESCRIPTION
This enables automatic publication of the spec as Working Draft to /TR whevener a commit is merged.

The publication token is set as a secret in the repo's settings.

Fixes #111.