### PR TITLE
Replace `window-placement` permission references with `window-management`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -22,6 +22,7 @@ aligning related proposals, partly motivating a new Screens interface.
   - `id`: A temporary generated per-origin unique ID; reset when cookies are deleted.
   - `touchSupport`: Whether the screen supports touch input; a predecessor of `pointerTypes`.
   - `pointerTypes`: The set of PointerTypes supported by the screen.
+- The `window-placement` permission and permission policy name were renamed to `window-management` as per GitHub issue [114](https://github.com/w3c/window-placement/issues/114)
 
 ## Examples of requesting additional screen information
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,8 +16,7 @@ aligning related proposals, partly motivating a new Screens interface.
 - Partner feedback requested access to:
   - User-friendly screen labels, which vastly improve custom multi-screen picker and configuration UIs for apps
   - Screen change events, including changes to the multi-screen bit, to obviate polling
-- Chrome Security requested that this feature be disabled by default on embedded pages via a [permissions policy](https://w3c.github.io/webappsec-permissions-policy/)
-  - In the second origin trial, cross origin iframes need to specify an `allow="window-management"` attribute.
+- Starting in the second origin trial, a [permissions policy](https://w3c.github.io/webappsec-permissions-policy/) was added, so embedders could control feature access of embedded iframes.
 - Some screen properties of reduced imperative were removed, at least for now.
   - `id`: A temporary generated per-origin unique ID; reset when cookies are deleted.
   - `touchSupport`: Whether the screen supports touch input; a predecessor of `pointerTypes`.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,7 +17,7 @@ aligning related proposals, partly motivating a new Screens interface.
   - User-friendly screen labels, which vastly improve custom multi-screen picker and configuration UIs for apps
   - Screen change events, including changes to the multi-screen bit, to obviate polling
 - Chrome Security requested that this feature be disabled by default on embedded pages via a [permissions policy](https://w3c.github.io/webappsec-permissions-policy/)
-  - In the second origin trial, cross origin iframes need to specify an `allow="window-placement"` attribute.
+  - In the second origin trial, cross origin iframes need to specify an `allow="window-management"` attribute.
 - Some screen properties of reduced imperative were removed, at least for now.
   - `id`: A temporary generated per-origin unique ID; reset when cookies are deleted.
   - `touchSupport`: Whether the screen supports touch input; a predecessor of `pointerTypes`.

--- a/EXPLAINER.md
+++ b/EXPLAINER.md
@@ -64,7 +64,7 @@ of existing window placement APIs to support extended multi-screen environments.
   * Add `Window.getScreenDetails()` to request additional permission-gated screen info
   * Add `ScreenDetails` and `ScreenDetailed` interfaces for additional screen info
   * Standardize common `Screen.availLeft` and `Screen.availTop` attributes
-  * Add Permission API support for a new `window-placement` entry
+  * Add Permission API support for a new `window-management` entry
 
 These allow web applications to make window placement requests optimized for the
 specific use case, characteristics of available screens, and user preferences.
@@ -524,7 +524,7 @@ window.moveTo(screen.availLeft + offsetX, screen.availTop + offsetY);
 See prior discussion regarding coordinates in the section titled
 "Support requests to place web app windows on a specific screen".
 
-### Add Permission API support for a new `window-placement` entry
+### Add Permission API support for a new `window-management` entry
 
 Sites may wish to know whether users have already granted or denied a requisite
 permission before attempting to access gated information and capabilities. The
@@ -534,7 +534,7 @@ the `query()` method of the [Permission API](https://w3c.github.io/permissions).
 ```webidl
 enum PermissionName {
   // ...
-  "window-placement",
+  "window-management",
   // ...
 };
 ```
@@ -544,7 +544,7 @@ cross-screen support for users that have already granted permission, and respect
 users that have already denied the permission.
 
 ```js
-navigator.permissions.query({name:'window-placement'}).then(function(status) {
+navigator.permissions.query({name:'window-management'}).then(function(status) {
   if (status.state === "prompt")
     showMultiScreenEducationalUI();
   else if (status.state === "granted")
@@ -561,7 +561,7 @@ If a cross-origin page wants an embedded page to have access to this API,
 then it needs to specify an `allow` attribute on the iframe, e.g.
 
 ```html
-<iframe src="some_page.html" allow="window-placement"></iframe>
+<iframe src="some_page.html" allow="window-management"></iframe>
 ```
 
 ### Open questions

--- a/EXPLAINER_initiating_multi_screen_experiences.md
+++ b/EXPLAINER_initiating_multi_screen_experiences.md
@@ -61,11 +61,11 @@ fullscreen request and a popup window request from a single user-activation.
 An eventual end-goal (that is not explored here) is to enable scripts to enter
 fullscreen on N screens and open M popup windows on M screens from a single user
 activation, where N and M are disjoint and potentially empty sets, as long as
-the site has the multi-screen `window-placement` permission.
+the site has the multi-screen `window-management` permission.
 
 ## Proposal
 
-Allow sites with the `window-placement` permission to
+Allow sites with the `window-management` permission to
 [place fullscreen content on a specific screen](https://webscreens.github.io/window-placement/#usage-overview-place-fullscreen-content-on-a-specific-screen)
 *and*
 [place a new popup window on a separate specific screen](https://webscreens.github.io/window-placement/#usage-overview-place-windows-on-a-specific-screen),
@@ -76,7 +76,7 @@ This fulfills the API partner’s use case in the most narrow manner possible, a
 limits the potential for accidental misuse or abuse with the following set of
 mitigations:
 
-- Require the window-placement permission and devices with multiple displays
+- Require the window-management permission and devices with multiple displays
   - These are needed to show a popup and fullscreen on separate displays
 - Allow opening a popup *after* requesting fullscreen on a specific display
   - This ordering prevents basic misuse (showing a popup under fullscreen)
@@ -98,7 +98,7 @@ precedent: requestFullscreen()
 [waives its activation requirement](https://fullscreen.spec.whatwg.org/#dom-element-requestfullscreen)
 on user generated orientation changes.
 
-Note: the `window-placement` permission is requested earlier, as needed, by
+Note: the `window-management` permission is requested earlier, as needed, by
 [`Window.getScreenDetails()`](https://w3c.github.io/window-placement/#dom-window-getscreendetails),
 before scripts can request fullscreen (or open a popup) on a specific screen.
 So it is expected that scripts making these requests already have permission.

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -42,7 +42,7 @@ async function main() {
 
 ## How to use API enhancements
 
-[Fullscreen Companion Window](https://chromestatus.com/feature/5173162437246976) permits sites with the window-placement permission to [initiate a multi-screen experience](https://github.com/w3c/window-placement/blob/main/EXPLAINER_initiating_multi_screen_experiences.md) from a single user activation. Specifically, this proposed enhancement allows scripts to open a popup window when requesting fullscreen on a specific screen of a multi-screen device. Test this by invoking "Fullscreen slide and open notes" in the [window-placement-demo](https://michaelwasserman.github.io/window-placement-demo).
+[Fullscreen Companion Window](https://chromestatus.com/feature/5173162437246976) permits sites with the window-management permission to [initiate a multi-screen experience](https://github.com/w3c/window-placement/blob/main/EXPLAINER_initiating_multi_screen_experiences.md) from a single user activation. Specifically, this proposed enhancement allows scripts to open a popup window when requesting fullscreen on a specific screen of a multi-screen device. Test this by invoking "Fullscreen slide and open notes" in the [window-placement-demo](https://michaelwasserman.github.io/window-placement-demo).
   - Chrome 104+ enables this enhancement by default.
   - Chrome 102+ supports this enhancement with this flag enabled:
     - `chrome --enable-features=WindowPlacementFullscreenCompanionWindow`

--- a/index.bs
+++ b/index.bs
@@ -502,7 +502,7 @@ The <dfn method for=Window>getScreenDetails()</dfn> method steps are:
 
 1. Run the following steps [=/in parallel=]:
 
-    1. Let |permissionState| be [=/request permission to use=] `"window-placement"`.
+    1. Let |permissionState| be [=/request permission to use=] `"window-management"`.
 
     1. If |permissionState| is "{{PermissionState/denied}}" then [=/reject=] |promise| with a {{"NotAllowedError"}} {{DOMException}} and abort these steps.
 
@@ -729,11 +729,11 @@ The {{Element/requestFullscreen|Element.requestFullscreen()}} method steps are u
 ## Permission API Integration ## {#api-permission-api-integration}
 <!-- ====================================================================== -->
 
-This specification defines a [=/default powerful feature=] that is identified by the [=powerful feature/name=] "<dfn export permission>window-placement</dfn>".
+This specification defines a [=/default powerful feature=] that is identified by the [=powerful feature/name=] "<dfn export permission>window-management</dfn>".
 
 The [[permissions]] API provides a uniform way for websites to query the state of their permissions.
 
-Issue: Add {{window-placement}} to [[permissions]] registry.
+Issue: Add {{window-management}} to [[permissions]] registry.
 
 Issue: Define behavior of cached objects and method steps when the permission is revoked. (See [#80](https://github.com/w3c/window-placement/issues/80))
 
@@ -741,11 +741,11 @@ Issue: Define behavior of cached objects and method steps when the permission is
 ## Permission Policy integration ## {#api-permission-policy-integration}
 <!-- ====================================================================== -->
 
-This specification defines a [=/policy-controlled feature=] identified by the string "<dfn for="permission-policy">window-placement</dfn>". Its [=/default allowlist=] is `"self"`. See [[permissions-policy]] and its list of [Experimental Features](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md#experimental-features).
+This specification defines a [=/policy-controlled feature=] identified by the string "<dfn for="permission-policy">window-management</dfn>". Its [=/default allowlist=] is `"self"`. See [[permissions-policy]] and its list of [Experimental Features](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md#experimental-features).
 
 Note: A [=/document=]’s permissions policy determines whether any content in that document is allowed to obtain {{ScreenDetails}} or place content on specific screens. If disabled, promises returned by {{Window/getScreenDetails}} will be rejected, and requests to place content on specific screens will be clamped to the [=/current screen=].
 
-Issue: Move [=permission-policy/window-placement=] to [Proposed](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md#proposed-features) or [Standardized](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md#proposed-features) feature lists when appropriate.
+Issue: Move [=permission-policy/window-management=] to [Proposed](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md#proposed-features) or [Standardized](https://github.com/w3c/webappsec-permissions-policy/blob/main/features.md#proposed-features) feature lists when appropriate.
 
 <!-- ====================================================================== -->
 # Security Considerations # {#security}

--- a/index.bs
+++ b/index.bs
@@ -733,6 +733,8 @@ This specification defines a [=/default powerful feature=] that is identified by
 
 The [[permissions]] API provides a uniform way for websites to query the state of their permissions.
 
+Note: Previously published versions of this document used the permission name "{{window-placement}}". User agents should carefully migrate to the updated permission string: "{{window-management}}". See [#114](https://github.com/w3c/window-placement/issues/114).
+
 Issue: Add {{window-management}} to [[permissions]] registry.
 
 Issue: Define behavior of cached objects and method steps when the permission is revoked. (See [#80](https://github.com/w3c/window-placement/issues/80))

--- a/security_and_privacy.md
+++ b/security_and_privacy.md
@@ -56,7 +56,7 @@ web application's window placement actions, and declarative arrangements
 specified by a site are unlikely to provide the requisite expressiveness for
 most use cases.
 
-All newly exposed information could be gated by the proposed `window-placement`
+All newly exposed information could be gated by the proposed `window-management`
 permission, limited to secure contexts, top-level frames, gated by user gesture,
 active window contexts, and other protections to help mitigate concerns around
 [fingerprinting](https://w3c.github.io/fingerprinting-guidance).
@@ -232,7 +232,7 @@ No.
 The questionnaire could ask if implementing the proposal would yield or enable
 any additional Security and Privacy protections.
 
-By adding the proposed `window-placement` permission, browsers could further
+By adding the proposed `window-management` permission, browsers could further
 limit unpermissioned access to existing information and capabilities.
 
 For example, without the permission, browsers could:


### PR DESCRIPTION
Resolves the first step in Issue #114 to rename the permission string from `window-placement` to `window-management`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/bradtriebwasser/window-placement/pull/115.html" title="Last updated on Oct 28, 2022, 6:20 PM UTC (76ff446)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/window-placement/115/b7e5a84...bradtriebwasser:76ff446.html" title="Last updated on Oct 28, 2022, 6:20 PM UTC (76ff446)">Diff</a>