### PR TITLE
Drop broken link to now gone "window-placement" permission

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -733,7 +733,7 @@ This specification defines a [=/default powerful feature=] that is identified by
 
 The [[permissions]] API provides a uniform way for websites to query the state of their permissions.
 
-Note: Previously published versions of this document used the permission name "{{window-placement}}". User agents should carefully migrate to the updated permission string: "{{window-management}}". See [#114](https://github.com/w3c/window-placement/issues/114).
+Note: Previously published versions of this document used the permission name "<code>window-placement</code>". User agents should carefully migrate to the updated permission string: "{{window-management}}". See [#114](https://github.com/w3c/window-placement/issues/114).
 
 Issue: Add {{window-management}} to [[permissions]] registry.
 


### PR DESCRIPTION
The `{{window-placement}}` construct can no longer be used since the spec no longer defines `window-placement`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/window-placement/pull/116.html" title="Last updated on Nov 1, 2022, 10:01 AM UTC (6c47981)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/window-placement/116/d90a9b7...6c47981.html" title="Last updated on Nov 1, 2022, 10:01 AM UTC (6c47981)">Diff</a>